### PR TITLE
fix pvc pruning on delete

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -165,6 +165,11 @@ func (o *DeleteOptions) Run() error {
 			return err
 		}
 
+		infos, err := result.Infos()
+		if err != nil {
+			return err
+		}
+
 		err = o.HookExecutor.ExecHooks(c, chart.PreDeleteHook)
 		if err != nil {
 			return err
@@ -172,7 +177,7 @@ func (o *DeleteOptions) Run() error {
 
 		err = o.Deleter.Delete(&deletions.Request{
 			Waiter:  o.Waiter,
-			Visitor: result,
+			Visitor: resource.InfoListVisitor(infos),
 		})
 		if err != nil {
 			return err
@@ -189,11 +194,8 @@ func (o *DeleteOptions) Run() error {
 			Waiter:         o.Waiter,
 		}
 
-		v, err := resources.NewVisitorFromResourceInfoVisitor(result)
-		if err != nil {
-			return err
-		}
+		visitor := resources.NewInfoListVisitor(infos)
 
-		return pvcPruner.Prune(v)
+		return pvcPruner.Prune(visitor)
 	})
 }

--- a/pkg/resources/visitor.go
+++ b/pkg/resources/visitor.go
@@ -27,25 +27,10 @@ func NewVisitor(objs []runtime.Object) Visitor {
 	}
 }
 
-// NewVisitorFromResourceInfoVisitor creates a new Visitor from a resource.Visitor
-func NewVisitorFromResourceInfoVisitor(visitor resource.Visitor) (Visitor, error) {
-	objs := make([]runtime.Object, 0)
-
-	err := visitor.Visit(func(info *resource.Info, err error) error {
-		if err != nil || info.Object == nil {
-			return err
-		}
-
-		objs = append(objs, info.Object)
-
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return NewVisitor(objs), nil
+// NewInfoListVisitor creates a new Visitor that visits all runtime objects
+// contained in the info list.
+func NewInfoListVisitor(infos []*resource.Info) Visitor {
+	return NewVisitor(ToObjectList(infos))
 }
 
 // Visit implements Visitor.
@@ -90,4 +75,15 @@ func (v *StatefulSetVisitor) Visit(fn VisitorFunc) error {
 
 		return fn(obj, nil)
 	})
+}
+
+// ToObjectList converts given info list to a slice of runtime objects.
+func ToObjectList(infos []*resource.Info) []runtime.Object {
+	objs := make([]runtime.Object, len(infos))
+
+	for i, info := range infos {
+		objs[i] = info.Object
+	}
+
+	return objs
 }


### PR DESCRIPTION
This PR fixes a bug where pvc pruning did not happen on `kubectl chart delete` because the builder result yields no objects when visited twice.