### PR TITLE
feature: resource operation coloring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/spec v0.19.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/pkg/chart/hook.go
+++ b/pkg/chart/hook.go
@@ -256,7 +256,7 @@ type HookExecutor struct {
 	Mapper        meta.RESTMapper
 	Deleter       deletions.Deleter
 	Waiter        wait.Waiter
-	Printer       printers.OperationPrinter
+	Printer       printers.ContextPrinter
 	DryRun        bool
 }
 
@@ -393,8 +393,6 @@ func (e *HookExecutor) waitForCompletion(infos []*resource.Info, options wait.Re
 
 // PrintHook prints a hooks.
 func (e *HookExecutor) PrintHook(hook *Hook) error {
-	operation := "triggered"
-
 	options := make([]string, 0)
 
 	if timeout, _ := hook.WaitTimeout(); timeout > 0 {
@@ -409,9 +407,8 @@ func (e *HookExecutor) PrintHook(hook *Hook) error {
 		options = append(options, "allow-failure")
 	}
 
-	if len(options) > 0 {
-		operation = fmt.Sprintf("%s (%s)", operation, strings.Join(options, ","))
-	}
-
-	return e.Printer.WithOperation(operation).PrintObj(hook, e.Out)
+	return e.Printer.
+		WithOperation("triggered").
+		WithContext(options...).
+		PrintObj(hook, e.Out)
 }

--- a/pkg/chart/hook.go
+++ b/pkg/chart/hook.go
@@ -256,6 +256,7 @@ type HookExecutor struct {
 	Mapper        meta.RESTMapper
 	Deleter       deletions.Deleter
 	Waiter        wait.Waiter
+	Printer       printers.OperationPrinter
 	DryRun        bool
 }
 
@@ -412,7 +413,5 @@ func (e *HookExecutor) PrintHook(hook *Hook) error {
 		operation = fmt.Sprintf("%s (%s)", operation, strings.Join(options, ","))
 	}
 
-	p := printers.NewNamePrinter(operation, e.DryRun)
-
-	return p.PrintObj(hook, e.Out)
+	return e.Printer.WithOperation(operation).PrintObj(hook, e.Out)
 }

--- a/pkg/chart/hook_test.go
+++ b/pkg/chart/hook_test.go
@@ -404,7 +404,7 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 				Waiter:        waiter,
 				Mapper:        testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 				DynamicClient: fakeClient,
-				Printer:       printers.NewDiscardingOperationPrinter(),
+				Printer:       printers.NewDiscardingContextPrinter(),
 				DryRun:        tc.dryRun,
 			}
 

--- a/pkg/chart/hook_test.go
+++ b/pkg/chart/hook_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/martinohmann/kubectl-chart/pkg/deletions"
+	"github.com/martinohmann/kubectl-chart/pkg/printers"
 	"github.com/martinohmann/kubectl-chart/pkg/wait"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -403,6 +404,7 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 				Waiter:        waiter,
 				Mapper:        testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 				DynamicClient: fakeClient,
+				Printer:       printers.NewDiscardingOperationPrinter(),
 				DryRun:        tc.dryRun,
 			}
 

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -78,7 +78,7 @@ type ApplyOptions struct {
 	ServerDryRun bool
 	ShowDiff     bool
 
-	Printer         printers.OperationPrinter
+	Printer         printers.ContextPrinter
 	Recorder        recorders.OperationRecorder
 	DynamicClient   dynamic.Interface
 	DiscoveryClient discovery.CachedDiscoveryInterface

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -58,7 +58,6 @@ func NewApplyCmd(f genericclioptions.RESTClientGetter, streams genericclioptions
 
 	o.ChartFlags.AddFlags(cmd)
 	o.HookFlags.AddFlags(cmd)
-	o.PrintFlags.AddFlags(cmd)
 	o.DiffFlags.AddFlags(cmd)
 
 	cmd.Flags().BoolVar(&o.ServerDryRun, "server-dry-run", o.ServerDryRun, "If true, request will be sent to server with dry-run flag, which means the modifications won't be persisted. This is an alpha feature and flag.")
@@ -73,7 +72,6 @@ type ApplyOptions struct {
 
 	ChartFlags   ChartFlags
 	HookFlags    HookFlags
-	PrintFlags   PrintFlags
 	DiffFlags    DiffFlags
 	DiffOptions  *DiffOptions
 	DryRun       bool
@@ -157,7 +155,7 @@ func (o *ApplyOptions) Complete(f genericclioptions.RESTClientGetter) error {
 
 	dryRun := o.DryRun || o.ServerDryRun
 
-	o.Printer = o.PrintFlags.ToPrinter(dryRun)
+	o.Printer = o.DiffFlags.PrintFlags.ToPrinter(dryRun)
 
 	o.Deleter = deletions.NewDeleter(
 		o.IOStreams,

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -45,6 +45,7 @@ func NewDeleteCmd(f genericclioptions.RESTClientGetter, streams genericclioption
 
 	o.ChartFlags.AddFlags(cmd)
 	o.HookFlags.AddFlags(cmd)
+	o.PrintFlags.AddFlags(cmd)
 
 	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "If true, only print the object that would be sent, without sending it. Warning: --dry-run cannot accurately output the result of merging the local manifest and the server-side data. Use --server-dry-run to get the merged result instead.")
 	cmd.Flags().BoolVar(&o.Prune, "prune", o.Prune, "If true, all resources matching the chart selector will be pruned, even those previously removed from the chart.")
@@ -57,6 +58,7 @@ type DeleteOptions struct {
 
 	ChartFlags ChartFlags
 	HookFlags  HookFlags
+	PrintFlags PrintFlags
 	DryRun     bool
 	Prune      bool
 
@@ -105,7 +107,9 @@ func (o *DeleteOptions) Complete(f genericclioptions.RESTClientGetter) error {
 		return err
 	}
 
-	o.Deleter = deletions.NewDeleter(o.IOStreams, o.DynamicClient, o.DryRun)
+	p := o.PrintFlags.ToPrinter(o.DryRun)
+
+	o.Deleter = deletions.NewDeleter(o.IOStreams, o.DynamicClient, p, o.DryRun)
 
 	if o.HookFlags.NoHooks {
 		o.HookExecutor = &hooks.NoopExecutor{}
@@ -117,6 +121,7 @@ func (o *DeleteOptions) Complete(f genericclioptions.RESTClientGetter) error {
 			Mapper:        o.Mapper,
 			Waiter:        wait.NewDefaultWaiter(o.IOStreams),
 			Deleter:       o.Deleter,
+			Printer:       p,
 		}
 	}
 

--- a/pkg/cmd/diff.go
+++ b/pkg/cmd/diff.go
@@ -30,8 +30,8 @@ func NewDiffCmd(f genericclioptions.RESTClientGetter, streams genericclioptions.
 		Example: `  # Diff a single chart
   kubectl chart diff --chart-dir ~/charts/mychart
 
-  # Diff multiple charts with custom diff context
-  kubectl chart diff --chart-dir ~/charts --recursive --diff-context 20`,
+  # Diff multiple charts with custom diff context and no coloring
+  kubectl chart diff --chart-dir ~/charts --recursive --diff-context 20 --no-color`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -80,6 +80,6 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.NoColor, "no-color", f.NoColor, "If set, output will not be colored")
 }
 
-func (f *PrintFlags) ToPrinter(dryRun bool) printers.OperationPrinter {
-	return printers.NewOperationPrinter(!f.NoColor, dryRun)
+func (f *PrintFlags) ToPrinter(dryRun bool) printers.ContextPrinter {
+	return printers.NewContextPrinter(!f.NoColor, dryRun)
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/martinohmann/kubectl-chart/pkg/chart"
 	"github.com/martinohmann/kubectl-chart/pkg/diff"
+	"github.com/martinohmann/kubectl-chart/pkg/printers"
 	"github.com/spf13/cobra"
 )
 
@@ -68,4 +69,16 @@ type HookFlags struct {
 
 func (f *HookFlags) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.NoHooks, "no-hooks", f.NoHooks, "If true, no hooks will be executed")
+}
+
+type PrintFlags struct {
+	Color bool
+}
+
+func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&f.Color, "color", f.Color, "If true, resource operations will be printed in color based on the operation type")
+}
+
+func (f *PrintFlags) ToPrinter(dryRun bool) printers.OperationPrinter {
+	return printers.NewOperationPrinter(f.Color, dryRun)
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -41,8 +41,8 @@ func (f *ChartFlags) ToVisitor(namespace string) (chart.Visitor, error) {
 }
 
 type DiffFlags struct {
-	NoColor bool
-	Context int
+	Context    int
+	PrintFlags PrintFlags
 }
 
 func NewDefaultDiffFlags() DiffFlags {
@@ -52,13 +52,14 @@ func NewDefaultDiffFlags() DiffFlags {
 }
 
 func (f *DiffFlags) AddFlags(cmd *cobra.Command) {
+	f.PrintFlags.AddFlags(cmd)
+
 	cmd.Flags().IntVar(&f.Context, "diff-context", f.Context, "Line context to display before and after each changed block")
-	cmd.Flags().BoolVar(&f.NoColor, "no-diff-color", f.NoColor, "Do not color diff output")
 }
 
 func (f *DiffFlags) ToPrinter() diff.Printer {
 	return diff.NewUnifiedPrinter(diff.Options{
-		Color:   !f.NoColor,
+		Color:   !f.PrintFlags.NoColor,
 		Context: f.Context,
 	})
 }
@@ -68,17 +69,17 @@ type HookFlags struct {
 }
 
 func (f *HookFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.NoHooks, "no-hooks", f.NoHooks, "If true, no hooks will be executed")
+	cmd.Flags().BoolVar(&f.NoHooks, "no-hooks", f.NoHooks, "If set, no hooks will be executed")
 }
 
 type PrintFlags struct {
-	Color bool
+	NoColor bool
 }
 
 func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&f.Color, "color", f.Color, "If true, resource operations will be printed in color based on the operation type")
+	cmd.Flags().BoolVar(&f.NoColor, "no-color", f.NoColor, "If set, output will not be colored")
 }
 
 func (f *PrintFlags) ToPrinter(dryRun bool) printers.OperationPrinter {
-	return printers.NewOperationPrinter(f.Color, dryRun)
+	return printers.NewOperationPrinter(!f.NoColor, dryRun)
 }

--- a/pkg/deletions/deleter.go
+++ b/pkg/deletions/deleter.go
@@ -33,13 +33,13 @@ type deleter struct {
 }
 
 // NewDeleter creates a new resource deleter.
-func NewDeleter(streams genericclioptions.IOStreams, client dynamic.Interface, dryRun bool) Deleter {
+func NewDeleter(streams genericclioptions.IOStreams, client dynamic.Interface, printer printers.OperationPrinter, dryRun bool) Deleter {
 	return &deleter{
 		IOStreams:     streams,
 		DynamicClient: client,
 		DryRun:        dryRun,
 		Waiter:        wait.NewDefaultWaiter(streams),
-		Printer:       printers.NewNamePrinter("deleted", dryRun),
+		Printer:       printer.WithOperation("deleted"),
 	}
 }
 

--- a/pkg/deletions/deleter.go
+++ b/pkg/deletions/deleter.go
@@ -33,7 +33,7 @@ type deleter struct {
 }
 
 // NewDeleter creates a new resource deleter.
-func NewDeleter(streams genericclioptions.IOStreams, client dynamic.Interface, printer printers.OperationPrinter, dryRun bool) Deleter {
+func NewDeleter(streams genericclioptions.IOStreams, client dynamic.Interface, printer printers.ContextPrinter, dryRun bool) Deleter {
 	return &deleter{
 		IOStreams:     streams,
 		DynamicClient: client,

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -1,9 +1,11 @@
 package printers
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
+	"github.com/fatih/color"
 	"github.com/martinohmann/kubectl-chart/pkg/recorders"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -12,7 +14,12 @@ import (
 // ResourcePrinter prints runtime objects.
 type ResourcePrinter interface {
 	// Print receives a runtime object, formats it and prints it to a writer.
-	PrintObj(runtime.Object, io.Writer) error
+	PrintObj(obj runtime.Object, w io.Writer) error
+}
+
+type OperationPrinter interface {
+	ResourcePrinter
+	WithOperation(operation string) OperationPrinter
 }
 
 // RecordingPrinter records all objects it prints.
@@ -48,4 +55,114 @@ func NewNamePrinter(operation string, dryRun bool) *printers.NamePrinter {
 	}
 
 	return &printers.NamePrinter{Operation: operation}
+}
+
+type colorFunc func(format string, a ...interface{}) string
+
+var (
+	colorMap = map[string]colorFunc{
+		"created":    color.GreenString,
+		"deleted":    color.RedString,
+		"pruned":     color.RedString,
+		"triggered":  color.CyanString,
+		"configured": color.YellowString,
+	}
+
+	operationPrefix = map[string]string{
+		"created":    "+",
+		"deleted":    "-",
+		"pruned":     "-",
+		"triggered":  "^",
+		"configured": "~",
+	}
+)
+
+type colorPrinter struct {
+	delegate ResourcePrinter
+	colorFn  colorFunc
+	prefix   string
+}
+
+// NewColorPrinter wraps delegate with a color printer for given operation.
+func NewColorPrinter(delegate ResourcePrinter, operation string) ResourcePrinter {
+	colorFn, ok := colorMap[operation]
+	if !ok {
+		colorFn = fmt.Sprintf
+	}
+
+	prefix, ok := operationPrefix[operation]
+	if !ok {
+		prefix = " "
+	}
+
+	return &colorPrinter{
+		delegate: delegate,
+		colorFn:  colorFn,
+		prefix:   prefix,
+	}
+}
+
+// PrintObj implements ResourcePrinter
+func (p *colorPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	var buf bytes.Buffer
+
+	err := p.delegate.PrintObj(obj, &buf)
+	if err != nil {
+		return err
+	}
+
+	colored := p.colorFn("%s %s", p.prefix, buf.String())
+
+	_, err = w.Write([]byte(colored))
+
+	return err
+}
+
+var _ OperationPrinter = &operationPrinter{}
+var _ OperationPrinter = &discardingOperationPrinter{}
+
+type operationPrinter struct {
+	ResourcePrinter
+	operation string
+	color     bool
+	dryRun    bool
+}
+
+func NewOperationPrinter(color, dryRun bool) OperationPrinter {
+	return newOperationPrinter("", color, dryRun)
+}
+
+func newOperationPrinter(operation string, color, dryRun bool) OperationPrinter {
+	var p ResourcePrinter
+
+	p = NewNamePrinter(operation, dryRun)
+
+	if color {
+		p = NewColorPrinter(p, operation)
+	}
+
+	return &operationPrinter{
+		ResourcePrinter: p,
+		operation:       operation,
+		color:           color,
+		dryRun:          dryRun,
+	}
+}
+
+func (p *operationPrinter) WithOperation(operation string) OperationPrinter {
+	return newOperationPrinter(operation, p.color, p.dryRun)
+}
+
+type discardingOperationPrinter struct{}
+
+func NewDiscardingOperationPrinter() OperationPrinter {
+	return &discardingOperationPrinter{}
+}
+
+func (p *discardingOperationPrinter) WithOperation(string) OperationPrinter {
+	return p
+}
+
+func (p *discardingOperationPrinter) PrintObj(runtime.Object, io.Writer) error {
+	return nil
 }

--- a/pkg/printers/printers_test.go
+++ b/pkg/printers/printers_test.go
@@ -2,8 +2,10 @@ package printers
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/martinohmann/kubectl-chart/pkg/recorders"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,19 +14,94 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-func TestNamePrinter(t *testing.T) {
-	obj := getJob()
+func TestContextPrinter(t *testing.T) {
+	// needed for making assertions about correct coloring
+	noColor := color.NoColor
+	defer func() { color.NoColor = noColor }()
 
-	buf := bytes.NewBuffer(nil)
+	color.NoColor = false
 
-	assert.NoError(t, NewNamePrinter("created", false).PrintObj(obj, buf))
-	assert.NoError(t, NewNamePrinter("deleted", true).PrintObj(obj, buf))
+	tests := []struct {
+		name     string
+		dryRun   bool
+		color    bool
+		printFn  func(t *testing.T, p ContextPrinter, w io.Writer)
+		expected string
+	}{
+		{
+			name: "simple",
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				assert.NoError(t, p.PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo\n",
+		},
+		{
+			name: "with operation",
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				assert.NoError(t, p.WithOperation("created").PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo created\n",
+		},
+		{
+			name: "with context",
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				assert.NoError(t, p.WithContext("no-wait").PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo (no-wait)\n",
+		},
+		{
+			name:   "dry run printer with context and operation",
+			dryRun: true,
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				p = p.WithContext("allow-failure", "timeout=10s").WithOperation("deleted")
+				assert.NoError(t, p.PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo deleted (allow-failure,timeout=10s) (dry run)\n",
+		},
+		{
+			name:  "operation with color",
+			color: true,
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				assert.NoError(t, p.WithOperation("created").PrintObj(getJob(), w))
+			},
+			expected: color.GreenString("job.batch/foo created\n"),
+		},
+		{
+			name: "last operation takes precedence",
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				p = p.WithOperation("created").WithOperation("deleted")
+				assert.NoError(t, p.PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo deleted\n",
+		},
+		{
+			name: "context does not accumulate",
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				p = p.WithContext("bar=bar").WithContext("foo=bar", "baz")
+				assert.NoError(t, p.PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo (foo=bar,baz)\n",
+		},
+		{
+			name:  "unknown operations are not colored",
+			color: true,
+			printFn: func(t *testing.T, p ContextPrinter, w io.Writer) {
+				assert.NoError(t, p.WithOperation("prettified").PrintObj(getJob(), w))
+			},
+			expected: "job.batch/foo prettified\n",
+		},
+	}
 
-	expected := `job.batch/foo created
-job.batch/foo deleted (dry run)
-`
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := NewContextPrinter(test.color, test.dryRun)
+			buf := bytes.NewBuffer(nil)
 
-	assert.Equal(t, expected, buf.String())
+			test.printFn(t, p, buf)
+
+			assert.Equal(t, test.expected, buf.String())
+		})
+	}
 }
 
 func TestRecordingPrinter(t *testing.T) {
@@ -54,4 +131,14 @@ func getJob() *v1.Job {
 			Namespace: "bar",
 		},
 	}
+}
+
+func TestDiscardingContextPrinter(t *testing.T) {
+	var buf bytes.Buffer
+
+	p := NewDiscardingContextPrinter()
+
+	p.WithContext("foo").WithOperation("bar").PrintObj(getJob(), &buf)
+
+	assert.Empty(t, buf.String())
 }


### PR DESCRIPTION
This PR implements colored output for resource operations which is enabled by default.

The new `--no-color` flag disables colored output. This also controls the diff coloring to avoid having multiple color flags.