### PR TITLE
fix resource deletions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad h1:x1lITOfDEbnzt8D1cZJsPbdnx/hnv28FxY2GKkxmxgU=
 k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apimachinery v0.0.0-20190703205208-4cfb76a8bf76 h1:vxMYBaJgczGAIpJAOBco2eHuFYIyDdNIebt60jxLauA=
+k8s.io/apimachinery v0.0.0-20190715170309-6171873045ff h1:xezFJNivtQCzq73n4MFKshwXX1ftSsxxK8k4BfVJ3X4=
 k8s.io/cli-runtime v0.0.0-20190314001948-2899ed30580f h1:gRAqn9Z3rp62UwLU3PdC7Lhmsvd3e9PXLsq7EG+bq1s=
 k8s.io/cli-runtime v0.0.0-20190314001948-2899ed30580f/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/cli-runtime v0.0.0-20190612131021-ced92c4c4749 h1:b9JPq8kYVRk39BUB7C33RzAVQxbEd7rNSjKHHiZDhVo=

--- a/pkg/deletions/deleter.go
+++ b/pkg/deletions/deleter.go
@@ -1,6 +1,8 @@
 package deletions
 
 import (
+	"fmt"
+
 	"github.com/martinohmann/kubectl-chart/pkg/printers"
 	"github.com/martinohmann/kubectl-chart/pkg/wait"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +53,9 @@ func (d *deleter) Delete(v resource.Visitor) error {
 	uidMap := wait.UIDMap{}
 
 	err := v.Visit(func(info *resource.Info, err error) error {
-		if err != nil {
+		if errors.IsNotFound(err) {
+			fmt.Fprintln(d.ErrOut, err)
+		} else if err != nil {
 			return err
 		}
 

--- a/pkg/deletions/deleter_test.go
+++ b/pkg/deletions/deleter_test.go
@@ -155,6 +155,51 @@ func TestDeleter_Delete(t *testing.T) {
 			},
 		},
 		{
+			name: "should ignore NotFound errors on last visited info",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-bar",
+					Namespace: "ns-bar",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
+				fakeClient.PrependReactor("delete", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					deleteAction := action.(clienttesting.DeleteAction)
+
+					if deleteAction.GetName() == "name-bar" {
+						return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-foo", "name-foo")), apierrors.NewNotFound(schema.GroupResource{Group: "group", Resource: "theresource"}, "name-foo")
+					}
+
+					return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-bar", "name-bar")), nil
+				})
+				return fakeClient
+			},
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("delete", "theresource") || actions[0].(clienttesting.DeleteAction).GetName() != "name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+
+				if !actions[1].Matches("delete", "theresource") || actions[1].(clienttesting.DeleteAction).GetName() != "name-bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
 			name: "aborts deletion for errors different from NotFoundError",
 			infos: []*resource.Info{
 				{

--- a/pkg/deletions/deleter_test.go
+++ b/pkg/deletions/deleter_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/martinohmann/kubectl-chart/pkg/wait"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,30 +81,6 @@ func TestDeleter_Delete(t *testing.T) {
 			},
 		},
 		{
-			name: "ignores a NotFound errors",
-			infos: []*resource.Info{
-				{
-					Mapping: &meta.RESTMapping{
-						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
-					},
-					Name:      "name-foo",
-					Namespace: "ns-foo",
-				},
-			},
-			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
-				return dynamicfakeclient.NewSimpleDynamicClient(scheme)
-			},
-
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("delete", "theresource") || actions[0].(clienttesting.DeleteAction).GetName() != "name-foo" {
-					t.Error(spew.Sdump(actions))
-				}
-			},
-		},
-		{
 			name:   "retrieves a single resource in dry run mode",
 			dryRun: true,
 			infos: []*resource.Info{
@@ -126,7 +104,135 @@ func TestDeleter_Delete(t *testing.T) {
 				if len(actions) != 1 {
 					t.Fatal(spew.Sdump(actions))
 				}
-				if !actions[0].Matches("get", "theresource") || actions[0].(clienttesting.DeleteAction).GetName() != "name-foo" {
+				if !actions[0].Matches("get", "theresource") || actions[0].(clienttesting.GetAction).GetName() != "name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "continues on NotFound errors",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-bar",
+					Namespace: "ns-bar",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
+				fakeClient.PrependReactor("delete", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					deleteAction := action.(clienttesting.DeleteAction)
+
+					if deleteAction.GetName() == "name-foo" {
+						return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-foo", "name-foo")), apierrors.NewNotFound(schema.GroupResource{Group: "group", Resource: "theresource"}, "name-foo")
+					}
+
+					return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-bar", "name-bar")), nil
+				})
+				return fakeClient
+			},
+
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("delete", "theresource") || actions[0].(clienttesting.DeleteAction).GetName() != "name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+
+				if !actions[1].Matches("delete", "theresource") || actions[1].(clienttesting.DeleteAction).GetName() != "name-bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "aborts deletion for errors different from NotFoundError",
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-bar",
+					Namespace: "ns-bar",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
+				fakeClient.PrependReactor("delete", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					deleteAction := action.(clienttesting.DeleteAction)
+
+					if deleteAction.GetName() == "name-foo" {
+						return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-foo", "name-foo")), apierrors.NewUnauthorized("unauthorized")
+					}
+
+					return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-bar", "name-bar")), nil
+				})
+				return fakeClient
+			},
+			expectedErr: "unauthorized",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("delete", "theresource") || actions[0].(clienttesting.DeleteAction).GetName() != "name-foo" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name:   "aborts dry run for errors different from NotFoundError",
+			dryRun: true,
+			infos: []*resource.Info{
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-foo",
+					Namespace: "ns-foo",
+				},
+				{
+					Mapping: &meta.RESTMapping{
+						Resource: schema.GroupVersionResource{Group: "group", Version: "version", Resource: "theresource"},
+					},
+					Name:      "name-bar",
+					Namespace: "ns-bar",
+				},
+			},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme)
+				fakeClient.PrependReactor("get", "theresource", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					getAction := action.(clienttesting.GetAction)
+
+					if getAction.GetName() == "name-foo" {
+						return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-foo", "name-foo")), apierrors.NewUnauthorized("unauthorized")
+					}
+
+					return true, newUnstructuredList(newUnstructured("group/version", "TheKind", "ns-bar", "name-bar")), nil
+				})
+				return fakeClient
+			},
+			expectedErr: "unauthorized",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("get", "theresource") || actions[0].(clienttesting.GetAction).GetName() != "name-foo" {
 					t.Error(spew.Sdump(actions))
 				}
 			},
@@ -141,6 +247,7 @@ func TestDeleter_Delete(t *testing.T) {
 				IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
 				DynamicClient: fakeClient,
 				Printer:       printers.NewDiscardingPrinter(),
+				Waiter:        wait.NewFakeWaiter(),
 				DryRun:        test.dryRun,
 			}
 

--- a/pkg/deletions/fake_test.go
+++ b/pkg/deletions/fake_test.go
@@ -40,7 +40,7 @@ func TestFakeDeleter_Delete(t *testing.T) {
 type errorVisitor struct{}
 
 func (*errorVisitor) Visit(fn resource.VisitorFunc) error {
-	return errors.New("whoops")
+	return fn(nil, errors.New("whoops"))
 }
 
 func TestFakeDeleter_DeleteForwardVisitorErrors(t *testing.T) {


### PR DESCRIPTION
This PR replaces the `--prune` functionality for the `kubectl chart delete` command because it misses out on lots of resources and thus behaves different than the user thinks. This is basically related to: https://github.com/kubernetes/kubectl/issues/151. We should implement walking all api-resources by ourselves to make this work as intended.

The second bug was related NotFoundErrors being silently swallowed which caused subsequent resources from being skipped to delete.