### PR TITLE
match flags with existing kubectl + helm flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ Features
 - Simple chart lifecycle hooks (similar to helm hooks)
 - Configurable pruning of PVC of deleted StatefulSets
 - Dumping of merged chart values for debugging
+- Color indicators for printed resource operations to increase visibility
 
 Roadmap / Planned features
 --------------------------
 
 - Full integration test coverage
 - Listing all deployed resources of a chart (similar to `kubectl get all` with filter)
-- Color indicators for printed resource operations to increase visibility
+- Delete chart resources by selector
+- Automatic PersistentVolumeClaim resizing
 - Optional rollback of partially applied changes on failure
 
 Installation
@@ -90,37 +92,37 @@ Usage examples
 Diff chart:
 
 ```
-kubectl chart diff --chart-dir path/to/chart
+kubectl chart diff -f path/to/chart
 ```
 
 Diff all charts in a directory:
 
 ```
-kubectl chart diff --chart-dir path/to/charts -R
+kubectl chart diff -f path/to/charts -R
 ```
 
 Dry run apply with chart value overrides:
 
 ```
-kubectl chart apply --chart-dir path/to/chart --server-dry-run --value-file path/to/values.yaml
+kubectl chart apply -f path/to/chart --server-dry-run --values path/to/values.yaml
 ```
 
 Dry run delete charts by filter:
 
 ```
-kubectl chart delete --chart-dir path/to/charts -R --chart-filter chart1,chart3 --dry-run
+kubectl chart delete -f path/to/charts -R --chart-filter chart1,chart3 --dry-run
 ```
 
 Render chart:
 
 ```
-kubectl chart render --chart-dir path/to/chart
+kubectl chart render -f path/to/chart
 ```
 
 Render chart hooks:
 
 ```
-kubectl chart render --chart-dir path/to/chart --hook all
+kubectl chart render -f path/to/chart --hook-type all
 ```
 
 How does it work?

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -35,19 +35,19 @@ func NewApplyCmd(f genericclioptions.RESTClientGetter, streams genericclioptions
 		Short: "Apply resources from one or multiple helm charts",
 		Long:  "Apply renders the resources of one or multiple helm charts and applies them to a cluster.",
 		Example: `  # Render and apply a single chart
-  kubectl chart apply --chart-dir ~/charts/mychart
+  kubectl chart apply -f ~/charts/mychart
 
   # Render and apply multiple charts with additional values merged
-  kubectl chart apply --chart-dir ~/charts --recursive --value-file ~/some/additional/values.yaml
+  kubectl chart apply -f ~/charts --recursive --values ~/some/additional/values.yaml
 
   # Dry run apply and print resource diffs
-  kubectl chart apply --chart-dir ~/charts/mychart --diff --server-dry-run
+  kubectl chart apply -f ~/charts/mychart --diff --server-dry-run
 
   # Render and apply multiple charts with a chart filter
-  kubectl chart apply --chart-dir ~/charts --recursive --chart-filter mychart
+  kubectl chart apply -f ~/charts --recursive --chart-filter mychart
 
   # Skip executing pre and post-apply hooks
-  kubectl chart apply --chart-dir ~/charts/mychart --no-hooks`,
+  kubectl chart apply -f ~/charts/mychart --no-hooks`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -26,16 +26,16 @@ func NewDeleteCmd(f genericclioptions.RESTClientGetter, streams genericclioption
 		Short: "Delete resources from one or multiple helm charts",
 		Long:  "Deletes resources of one or multiple helm charts from a cluster.",
 		Example: `  # Delete resources of a single chart
-  kubectl chart delete --chart-dir ~/charts/mychart
+  kubectl chart delete -f ~/charts/mychart
 
   # Delete resources of multiple charts
-  kubectl chart delete --chart-dir ~/charts --recursive
+  kubectl chart delete -f ~/charts --recursive
 
   # Dry run resource deletion
-  kubectl chart delete --chart-dir ~/charts/mychart --dry-run
+  kubectl chart delete -f ~/charts/mychart --dry-run
 
   # Skip executing pre and post-delete hooks
-  kubectl chart delete --chart-dir ~/charts/mychart --no-hooks`,
+  kubectl chart delete -f ~/charts/mychart --no-hooks`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))

--- a/pkg/cmd/diff.go
+++ b/pkg/cmd/diff.go
@@ -28,10 +28,10 @@ func NewDiffCmd(f genericclioptions.RESTClientGetter, streams genericclioptions.
 		Short: "Diff resources from one or multiple helm charts",
 		Long:  "Diffs resources of one or multiple helm charts against the live objects in the cluster.",
 		Example: `  # Diff a single chart
-  kubectl chart diff --chart-dir ~/charts/mychart
+  kubectl chart diff -f ~/charts/mychart
 
   # Diff multiple charts with custom diff context and no coloring
-  kubectl chart diff --chart-dir ~/charts --recursive --diff-context 20 --no-color`,
+  kubectl chart diff -f ~/charts --recursive --diff-context 20 --no-color`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))

--- a/pkg/cmd/dump_values.go
+++ b/pkg/cmd/dump_values.go
@@ -22,13 +22,13 @@ func NewDumpValuesCmd(f genericclioptions.RESTClientGetter, streams genericcliop
 		Short: "Dump merged values for a chart",
 		Long:  "This command dumps the merged values for the provided charts how they would be available in templates. This is useful for debugging.",
 		Example: `  # Dump values for a single chart
-  kubectl chart dump-values --chart-dir ~/charts/mychart
+  kubectl chart dump-values -f ~/charts/mychart
 
   # Dump values for multiple charts with additional values merged
-  kubectl chart dump-values --chart-dir ~/charts --recursive --value-file ~/some/additional/values.yaml
+  kubectl chart dump-values -f ~/charts --recursive --values ~/some/additional/values.yaml
 
   # Dump values for multiple charts with filter
-  kubectl chart dump-values --chart-dir ~/charts --recursive --chart-filter mychart`,
+  kubectl chart dump-values -f ~/charts --recursive --chart-filter mychart`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -17,10 +17,10 @@ type ChartFlags struct {
 }
 
 func (f *ChartFlags) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&f.ChartDir, "chart-dir", f.ChartDir, "Directory of the helm chart that should be rendered. If not set the current directory is assumed")
+	cmd.Flags().StringVarP(&f.ChartDir, "chart-dir", "f", f.ChartDir, "Directory of the helm chart that should be rendered. If not set the current directory is assumed")
 	cmd.Flags().StringSliceVar(&f.ChartFilter, "chart-filter", f.ChartFilter, "If set only render filtered charts")
 	cmd.Flags().BoolVarP(&f.Recursive, "recursive", "R", f.Recursive, "If set all charts in --chart-dir will be recursively rendered")
-	cmd.Flags().StringArrayVar(&f.ValueFiles, "value-file", f.ValueFiles, "File that should be merged onto the chart values before rendering")
+	cmd.Flags().StringArrayVar(&f.ValueFiles, "values", f.ValueFiles, "File that should be merged onto the chart values before rendering")
 }
 
 func (f *ChartFlags) ToVisitor(namespace string) (chart.Visitor, error) {

--- a/pkg/cmd/render.go
+++ b/pkg/cmd/render.go
@@ -19,16 +19,16 @@ func NewRenderCmd(f genericclioptions.RESTClientGetter, streams genericclioption
 		Short: "Render resources from one or multiple helm charts",
 		Long:  "Renders resources of one or multiple helm charts. This can be used to preview the manifests that are sent to the cluster.",
 		Example: `  # Render a single chart
-  kubectl chart render --chart-dir ~/charts/mychart
+  kubectl chart render -f ~/charts/mychart
 
   # Render multiple charts
-  kubectl chart render --chart-dir ~/charts --recursive
+  kubectl chart render -f ~/charts --recursive
 
   # Render chart hooks
-  kubectl chart render --chart-dir ~/charts/mychart --hook pre-apply
+  kubectl chart render -f ~/charts/mychart --hook-type pre-apply
 
   # Render all chart hooks
-  kubectl chart render --chart-dir ~/charts --recursive --hook all`,
+  kubectl chart render -f ~/charts --recursive --hook-type all`,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f))
@@ -39,7 +39,7 @@ func NewRenderCmd(f genericclioptions.RESTClientGetter, streams genericclioption
 
 	o.ChartFlags.AddFlags(cmd)
 
-	cmd.Flags().StringVar(&o.HookType, "hook", o.HookType, "If provided hooks with given type will be rendered")
+	cmd.Flags().StringVar(&o.HookType, "hook-type", o.HookType, "If provided hooks with given type will be rendered")
 
 	return cmd
 }


### PR DESCRIPTION
The `--chart-dir` flag is now also available as `-f` to better integrate
with the `kubectl apply -f` workflow. Also the `--value-file` flag was
renamed to `--values` to match the flag helm uses for the same purpose.
To avoid confusion, the `--hook` flag was renamed to `--hook-type` to
make clean that a hook type is expected and not a hook name.

This change also updates the roadmap in README.md with some planned
features.