### PR TITLE
properly delete resources absent from rendered manifest

### DIFF
--- a/pkg/resources/finder.go
+++ b/pkg/resources/finder.go
@@ -1,0 +1,134 @@
+package resources
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog"
+)
+
+// DefaultSupportedVerbs is the list of verbs that is used when a *Finder is
+// created via NewFinder.
+var DefaultSupportedVerbs = metav1.Verbs{"get", "update", "list", "delete", "watch"}
+
+// Finder is a resource finder.
+type Finder struct {
+	DiscoveryClient discovery.DiscoveryInterface
+	DynamicClient   dynamic.Interface
+	Mapper          meta.RESTMapper
+	SupportedVerbs  metav1.Verbs
+}
+
+// NewFinder creates a new *Finder value.
+func NewFinder(client discovery.DiscoveryInterface, dynamicClient dynamic.Interface, mapper meta.RESTMapper) *Finder {
+	return &Finder{
+		DiscoveryClient: client,
+		DynamicClient:   dynamicClient,
+		Mapper:          mapper,
+		SupportedVerbs:  DefaultSupportedVerbs,
+	}
+}
+
+// FindByLabelSelector finds all resources that match given label selector and
+// returns the resource infos for them. It will only include resources that do
+// at least support the verbs specified in f.SupportedVerbs.
+func (f *Finder) FindByLabelSelector(selector string) ([]*resource.Info, error) {
+	mappings, err := f.getMappings()
+	if err != nil {
+		return nil, err
+	}
+
+	infos := []*resource.Info{}
+
+	for _, m := range mappings {
+		objList, err := f.DynamicClient.
+			Resource(m.Resource).
+			Namespace(metav1.NamespaceAll).
+			List(metav1.ListOptions{
+				LabelSelector: selector,
+			})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+
+		if apierrors.IsForbidden(err) || apierrors.IsMethodNotSupported(err) {
+			// If we are not allowed to access a resource or for some reason it
+			// does not support list, we should not fail.
+			klog.V(1).Info(err)
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, obj := range objList.Items {
+			obj := obj // copy
+
+			infos = append(infos, &resource.Info{
+				Mapping:         m,
+				Namespace:       obj.GetNamespace(),
+				Name:            obj.GetName(),
+				Object:          &obj,
+				ResourceVersion: obj.GetResourceVersion(),
+			})
+		}
+	}
+
+	return infos, nil
+}
+
+func (f *Finder) getMappings() ([]*meta.RESTMapping, error) {
+	_, lists, err := f.DiscoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return nil, err
+	}
+
+	mappings := make([]*meta.RESTMapping, 0)
+	seenGKs := make(map[schema.GroupKind]bool)
+
+	for _, list := range lists {
+		gv, _ := schema.ParseGroupVersion(list.GroupVersion)
+
+		for _, resource := range list.APIResources {
+			if len(resource.Verbs) == 0 {
+				continue
+			}
+
+			verbs := sets.NewString(resource.Verbs...)
+
+			if len(f.SupportedVerbs) > 0 && !verbs.HasAll(f.SupportedVerbs...) {
+				continue
+			}
+
+			group := resource.Group
+			if group == "" {
+				group = gv.Group
+			}
+
+			gk := schema.GroupKind{
+				Group: group,
+				Kind:  resource.Kind,
+			}
+
+			if seenGKs[gk] {
+				continue
+			}
+
+			mapping, err := f.Mapper.RESTMapping(gk)
+			if err != nil {
+				return nil, err
+			}
+
+			mappings = append(mappings, mapping)
+			seenGKs[gk] = true
+		}
+	}
+
+	return mappings, nil
+}

--- a/pkg/resources/finder_test.go
+++ b/pkg/resources/finder_test.go
@@ -1,0 +1,500 @@
+package resources
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func newUnstructuredList(items ...*unstructured.Unstructured) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	for i := range items {
+		item := *items[i]
+		list.Items = append(list.Items, item)
+	}
+	return list
+}
+
+func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return newUnstructuredWithLabels(apiVersion, kind, namespace, name, nil)
+}
+
+func newUnstructuredWithLabels(apiVersion, kind, namespace, name string, labels map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+				"labels":    labels,
+			},
+		},
+	}
+}
+
+func TestFinder_FindByLabelSelector(t *testing.T) {
+	tests := []struct {
+		name          string
+		fakeClient    func() *dynamicfakeclient.FakeDynamicClient
+		fakeDiscovery func() *fakediscovery.FakeDiscovery
+		verbs         metav1.Verbs
+		selector      string
+
+		expectedErr              string
+		validateDiscoveryActions func(t *testing.T, actions []clienttesting.Action)
+		validateDynamicActions   func(t *testing.T, actions []clienttesting.Action)
+		validateInfos            func(t *testing.T, infos []*resource.Info)
+	}{
+		{
+			name:     "find resources that support any verbs",
+			selector: "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("v1", "Pod", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				fakeClient.PrependReactor("list", "daemonsets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("apps/v1", "DaemonSet", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"sleep"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"get"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "pods") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+
+				if !actions[1].Matches("list", "daemonsets") || actions[1].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+			validateInfos: func(t *testing.T, infos []*resource.Info) {
+				require.Len(t, infos, 2)
+
+				assert.Equal(t, "Pod", infos[0].Object.GetObjectKind().GroupVersionKind().Kind)
+				assert.Equal(t, "DaemonSet", infos[1].Object.GetObjectKind().GroupVersionKind().Kind)
+			},
+		},
+		{
+			name:     "find resources that support all required verbs",
+			selector: "foo=bar",
+			verbs:    metav1.Verbs{"list", "delete", "update"},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "daemonsets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("apps/v1", "DaemonSet", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"sleep"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list", "delete", "update"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "daemonsets") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+			validateInfos: func(t *testing.T, infos []*resource.Info) {
+				require.Len(t, infos, 1)
+
+				assert.Equal(t, "DaemonSet", infos[0].Object.GetObjectKind().GroupVersionKind().Kind)
+			},
+		},
+		{
+			name:     "does not find duplicate GroupKinds twice",
+			selector: "foo=bar",
+			verbs:    metav1.Verbs{"list", "delete", "update"},
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "daemonsets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("apps/v1", "DaemonSet", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"list"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list", "delete", "update"}},
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list", "delete", "update"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "daemonsets") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+			validateInfos: func(t *testing.T, infos []*resource.Info) {
+				require.Len(t, infos, 1)
+
+				assert.Equal(t, "DaemonSet", infos[0].Object.GetObjectKind().GroupVersionKind().Kind)
+			},
+		},
+		{
+			name:     "ignores NotFound errors",
+			selector: "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "name-foo")
+				})
+				fakeClient.PrependReactor("list", "daemonsets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("apps/v1", "DaemonSet", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"get"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "pods") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+
+				if !actions[1].Matches("list", "daemonsets") || actions[1].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+			validateInfos: func(t *testing.T, infos []*resource.Info) {
+				require.Len(t, infos, 1)
+
+				assert.Equal(t, "DaemonSet", infos[0].Object.GetObjectKind().GroupVersionKind().Kind)
+			},
+		},
+		{
+			name:     "ignores Forbidden errors",
+			selector: "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "name-foo", errors.New("not allowed"))
+				})
+				fakeClient.PrependReactor("list", "daemonsets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, newUnstructuredList(newUnstructuredWithLabels("apps/v1", "DaemonSet", "ns-foo", "name-foo", map[string]interface{}{"foo": "bar"})), nil
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"get"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "pods") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+
+				if !actions[1].Matches("list", "daemonsets") || actions[1].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+			validateInfos: func(t *testing.T, infos []*resource.Info) {
+				require.Len(t, infos, 1)
+
+				assert.Equal(t, "DaemonSet", infos[0].Object.GetObjectKind().GroupVersionKind().Kind)
+			},
+		},
+		{
+			name:        "does stop on errors unhandled API errors",
+			expectedErr: `bad request`,
+			selector:    "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				fakeClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+				fakeClient.PrependReactor("list", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, apierrors.NewBadRequest("bad request")
+				})
+				return fakeClient
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: corev1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "nodes", Namespaced: false, Kind: "Node"},
+							{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"get"}},
+							{Name: "replicationcontrollers", Namespaced: true, Kind: "ReplicationController"},
+						},
+					},
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+
+				if !actions[0].Matches("list", "pods") || actions[0].(clienttesting.ListAction).GetListRestrictions().Labels.String() != "foo=bar" {
+					t.Error(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name:        "does stop on discovery errors",
+			expectedErr: `unexpected GroupVersion string: invalid/group/version`,
+			selector:    "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: "invalid/group/version",
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name:        "does stop on mapping errors",
+			expectedErr: `no matches for kind "FooBarBaz" in group "apps"`,
+			selector:    "foo=bar",
+			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
+				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
+			},
+			fakeDiscovery: func() *fakediscovery.FakeDiscovery {
+				fakeDiscovery := &fakediscovery.FakeDiscovery{Fake: &clienttesting.Fake{}}
+				fakeDiscovery.Resources = []*metav1.APIResourceList{
+					{
+						GroupVersion: appsv1.SchemeGroupVersion.String(),
+						APIResources: []metav1.APIResource{
+							{Name: "daemonsets", Namespaced: true, Kind: "DaemonSet", Verbs: metav1.Verbs{"list"}},
+							{Name: "foobarbaz", Namespaced: true, Kind: "FooBarBaz", Verbs: metav1.Verbs{"list"}},
+							{Name: "statefulsets", Namespaced: true, Kind: "StatefulSet"},
+						},
+					},
+				}
+
+				return fakeDiscovery
+			},
+			validateDiscoveryActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 2 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+			validateDynamicActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := tc.fakeClient()
+			fakeDiscovery := tc.fakeDiscovery()
+
+			f := &Finder{
+				DynamicClient:   fakeClient,
+				DiscoveryClient: fakeDiscovery,
+				Mapper:          testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
+				SupportedVerbs:  tc.verbs,
+			}
+
+			infos, err := f.FindByLabelSelector(tc.selector)
+			switch {
+			case err == nil && len(tc.expectedErr) == 0:
+			case err != nil && len(tc.expectedErr) == 0:
+				t.Fatal(err)
+			case err == nil && len(tc.expectedErr) != 0:
+				t.Fatalf("missing: %q", tc.expectedErr)
+			case err != nil && len(tc.expectedErr) != 0:
+				if !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("expected %q, got %q", tc.expectedErr, err.Error())
+				}
+			}
+
+			if tc.validateDiscoveryActions != nil {
+				tc.validateDiscoveryActions(t, fakeDiscovery.Actions())
+			}
+
+			if tc.validateDynamicActions != nil {
+				tc.validateDynamicActions(t, fakeClient.Actions())
+			}
+
+			if tc.validateInfos != nil {
+				tc.validateInfos(t, infos)
+			}
+		})
+	}
+}

--- a/pkg/resources/kind_sorter_test.go
+++ b/pkg/resources/kind_sorter_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/resource"
 )
 
 type nameKind struct {
@@ -62,24 +62,36 @@ func TestSortByKind_DeleteOrder(t *testing.T) {
 	assert.Equal(t, expected, SortByKind(given, DeleteOrder))
 }
 
+func TestSortInfosByKind_ApplyOrder(t *testing.T) {
+	given := nameKindsToObjectList(unsorted)
+	expected := nameKindsToObjectList(sortedForApply)
+
+	assert.Equal(t, expected, SortByKind(given, ApplyOrder))
+}
+
+func TestSortInfosByKind_DeleteOrder(t *testing.T) {
+	given := nameKindsToInfoList(unsorted)
+	expected := nameKindsToInfoList(sortedForDelete)
+
+	assert.Equal(t, expected, SortInfosByKind(given, DeleteOrder))
+}
+
 func nameKindsToObjectList(nameKinds []nameKind) []runtime.Object {
 	objs := make([]runtime.Object, len(nameKinds))
 
 	for i, nk := range nameKinds {
-		objs[i] = newUnstructured(nk.kind, nk.name)
+		objs[i] = newUnstructured("group/version", nk.kind, "ns-foo", nk.name)
 	}
 
 	return objs
 }
 
-func newUnstructured(kind, name string) runtime.Object {
-	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       kind,
-			"metadata": map[string]interface{}{
-				"name": name,
-			},
-		},
+func nameKindsToInfoList(nameKinds []nameKind) []*resource.Info {
+	objs := make([]*resource.Info, len(nameKinds))
+
+	for i, nk := range nameKinds {
+		objs[i] = &resource.Info{Object: newUnstructured("group/version", nk.kind, "ns-foo", nk.name)}
 	}
+
+	return objs
 }


### PR DESCRIPTION
This does implement a first version of proper resource deletion by chart
label.

The changes are as follows:

* If the `delete` command is called with the `--prune` flag, instead of
  deleting all resources defined in the rendered chart, the server is
  queried for all resources matching the chart label and deletes those.
* If the `apply` command is called on an empty chart, resource pruning
  did not work until now, as `apply` requires the rendered manifest to
  define at least one resource. Now, in case there are none, the
  behaviour is exactly the same as for the `delete --prune` command,
  except that potential delete hooks are skipped. To disable this
  behaviour `--prune=false` can be passed to the `apply` command.
  However, this will disable resource pruning completely.