### PR TITLE
remove hook executor interface

### DIFF
--- a/pkg/chart/hook_executor_test.go
+++ b/pkg/chart/hook_executor_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/martinohmann/kubectl-chart/pkg/meta"
 	"github.com/martinohmann/kubectl-chart/pkg/printers"
 	"github.com/martinohmann/kubectl-chart/pkg/wait"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kmeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
@@ -410,7 +411,7 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			deleter := deletions.NewFakeDeleter()
 			waiter := wait.NewFakeWaiter()
 
-			e := &hookExecutor{
+			e := &HookExecutor{
 				IOStreams:     genericclioptions.NewTestIOStreamsDiscard(),
 				Deleter:       deleter,
 				Waiter:        waiter,
@@ -446,6 +447,12 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHookExecutor_ExecHooks_Nil(t *testing.T) {
+	var executor *HookExecutor
+
+	assert.NoError(t, executor.ExecHooks(&Chart{}, hook.PreApply))
 }
 
 func newTestChart(hooks hook.Map) *Chart {

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -96,7 +96,7 @@ type ApplyOptions struct {
 	BuilderFactory  func() *resource.Builder
 	Encoder         resources.Encoder
 	Visitor         chart.Visitor
-	HookExecutor    chart.HookExecutor
+	HookExecutor    *chart.HookExecutor
 	Deleter         deletions.Deleter
 
 	Namespace        string
@@ -176,9 +176,7 @@ func (o *ApplyOptions) Complete(f genericclioptions.RESTClientGetter) error {
 		dryRun,
 	)
 
-	if o.HookFlags.NoHooks {
-		o.HookExecutor = &chart.NoopHookExecutor{}
-	} else {
+	if !o.HookFlags.NoHooks {
 		o.HookExecutor = chart.NewHookExecutor(
 			o.IOStreams,
 			o.DynamicClient,

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -69,7 +69,7 @@ type DeleteOptions struct {
 	Mapper          meta.RESTMapper
 	Encoder         resources.Encoder
 	Visitor         chart.Visitor
-	HookExecutor    chart.HookExecutor
+	HookExecutor    *chart.HookExecutor
 	Deleter         deletions.Deleter
 
 	Namespace        string
@@ -121,9 +121,7 @@ func (o *DeleteOptions) Complete(f genericclioptions.RESTClientGetter) error {
 
 	o.Deleter = deletions.NewDeleter(o.IOStreams, o.DynamicClient, p, o.DryRun)
 
-	if o.HookFlags.NoHooks {
-		o.HookExecutor = &chart.NoopHookExecutor{}
-	} else {
+	if !o.HookFlags.NoHooks {
 		o.HookExecutor = chart.NewHookExecutor(
 			o.IOStreams,
 			o.DynamicClient,


### PR DESCRIPTION
The `HookExecutor` interface and the `NoopHookExecutor` type are
obsolete and can be replaced by a simple `nil` check. If the executor is
`nil` calls to `ExecHooks` are no-ops.