### PR TITLE
refactor hook parsing logic

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -8,7 +8,7 @@ import (
 	"github.com/martinohmann/kubectl-chart/pkg/hook"
 	"github.com/martinohmann/kubectl-chart/pkg/meta"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
@@ -29,6 +29,12 @@ type Chart struct {
 // for more information.
 func LabelSelector(c *Chart) string {
 	return fmt.Sprintf("%s=%s", meta.LabelChartName, c.Config.Name)
+}
+
+// HookLabelSelector returns a selector which can be used to find hooks of given
+// type for given chart in a cluster.
+func HookLabelSelector(chartName, hookType string) string {
+	return fmt.Sprintf("%s=%s,%s=%s", meta.LabelHookChartName, chartName, meta.LabelHookType, hookType)
 }
 
 // Config is the configuration for rendering a chart.

--- a/pkg/chart/hook_executor_test.go
+++ b/pkg/chart/hook_executor_test.go
@@ -50,35 +50,33 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
 			},
-			hookType: hook.PreApply,
+			hookType: hook.TypePreApply,
 			hooks: hook.Map{
-				hook.PreApply: hook.List{
-					&hook.Hook{
-						Unstructured: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"apiVersion": "batch/v1",
-								"kind":       "Job",
-								"metadata": map[string]interface{}{
-									"name":      "somehook",
-									"namespace": "bar",
-									"annotations": map[string]interface{}{
-										meta.AnnotationHookType: hook.PreApply,
-									},
-									"labels": map[string]interface{}{
-										meta.LabelHookChartName: "foochart",
-										meta.LabelHookType:      hook.PreApply,
-									},
+				hook.TypePreApply: hook.List{
+					hook.MustParse(&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "batch/v1",
+							"kind":       "Job",
+							"metadata": map[string]interface{}{
+								"name":      "somehook",
+								"namespace": "bar",
+								"annotations": map[string]interface{}{
+									meta.AnnotationHookType: hook.TypePreApply,
 								},
-								"spec": map[string]interface{}{
-									"template": map[string]interface{}{
-										"spec": map[string]interface{}{
-											"restartPolicy": "Never",
-										},
+								"labels": map[string]interface{}{
+									meta.LabelHookChartName: "foochart",
+									meta.LabelHookType:      hook.TypePreApply,
+								},
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"restartPolicy": "Never",
 									},
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
@@ -124,36 +122,34 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
 			},
-			hookType: hook.PreApply,
+			hookType: hook.TypePreApply,
 			hooks: hook.Map{
-				hook.PreApply: hook.List{
-					&hook.Hook{
-						Unstructured: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"apiVersion": "batch/v1",
-								"kind":       "Job",
-								"metadata": map[string]interface{}{
-									"name":      "somehook",
-									"namespace": "bar",
-									"annotations": map[string]interface{}{
-										meta.AnnotationHookType:   hook.PreApply,
-										meta.AnnotationHookNoWait: "true",
-									},
-									"labels": map[string]interface{}{
-										meta.LabelHookChartName: "foochart",
-										meta.LabelHookType:      hook.PreApply,
-									},
+				hook.TypePreApply: hook.List{
+					hook.MustParse(&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "batch/v1",
+							"kind":       "Job",
+							"metadata": map[string]interface{}{
+								"name":      "somehook",
+								"namespace": "bar",
+								"annotations": map[string]interface{}{
+									meta.AnnotationHookType:   hook.TypePreApply,
+									meta.AnnotationHookNoWait: "true",
 								},
-								"spec": map[string]interface{}{
-									"template": map[string]interface{}{
-										"spec": map[string]interface{}{
-											"restartPolicy": "Never",
-										},
+								"labels": map[string]interface{}{
+									meta.LabelHookChartName: "foochart",
+									meta.LabelHookType:      hook.TypePreApply,
+								},
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"restartPolicy": "Never",
 									},
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
@@ -191,38 +187,36 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
 			},
-			hookType: hook.PreApply,
+			hookType: hook.TypePreApply,
 			hooks: hook.Map{
-				hook.PreApply: hook.List{
-					&hook.Hook{
-						Unstructured: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"apiVersion": "batch/v1",
-								"kind":       "Job",
-								"metadata": map[string]interface{}{
-									"name":      "somehook",
-									"namespace": "bar",
-									"annotations": map[string]interface{}{
-										meta.AnnotationHookType:         hook.PreApply,
-										meta.AnnotationHookAllowFailure: "true",
-										meta.AnnotationHookWaitTimeout:  "1h",
-									},
-									"labels": map[string]interface{}{
-										meta.LabelHookChartName: "foochart",
-										meta.LabelHookType:      hook.PreApply,
-									},
-									"uid": "some-uid",
+				hook.TypePreApply: hook.List{
+					hook.MustParse(&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "batch/v1",
+							"kind":       "Job",
+							"metadata": map[string]interface{}{
+								"name":      "somehook",
+								"namespace": "bar",
+								"annotations": map[string]interface{}{
+									meta.AnnotationHookType:         hook.TypePreApply,
+									meta.AnnotationHookAllowFailure: "true",
+									meta.AnnotationHookWaitTimeout:  "1h",
 								},
-								"spec": map[string]interface{}{
-									"template": map[string]interface{}{
-										"spec": map[string]interface{}{
-											"restartPolicy": "Never",
-										},
+								"labels": map[string]interface{}{
+									meta.LabelHookChartName: "foochart",
+									meta.LabelHookType:      hook.TypePreApply,
+								},
+								"uid": "some-uid",
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"restartPolicy": "Never",
 									},
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
@@ -271,38 +265,36 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 			fakeClient: func() *dynamicfakeclient.FakeDynamicClient {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
 			},
-			hookType: hook.PreApply,
+			hookType: hook.TypePostApply,
 			hooks: hook.Map{
-				hook.PreApply: hook.List{
-					&hook.Hook{
-						Unstructured: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"apiVersion": "batch/v1",
-								"kind":       "Job",
-								"metadata": map[string]interface{}{
-									"name":      "somehook",
-									"namespace": "bar",
-									"annotations": map[string]interface{}{
-										meta.AnnotationHookType:         hook.PostApply,
-										meta.AnnotationHookAllowFailure: "true",
-										meta.AnnotationHookWaitTimeout:  "0s",
-									},
-									"labels": map[string]interface{}{
-										meta.LabelHookChartName: "foochart",
-										meta.LabelHookType:      hook.PreApply,
-									},
-									"uid": "some-uid",
+				hook.TypePostApply: hook.List{
+					hook.MustParse(&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "batch/v1",
+							"kind":       "Job",
+							"metadata": map[string]interface{}{
+								"name":      "somehook",
+								"namespace": "bar",
+								"annotations": map[string]interface{}{
+									meta.AnnotationHookType:         hook.TypePostApply,
+									meta.AnnotationHookAllowFailure: "true",
+									meta.AnnotationHookWaitTimeout:  "0s",
 								},
-								"spec": map[string]interface{}{
-									"template": map[string]interface{}{
-										"spec": map[string]interface{}{
-											"restartPolicy": "Never",
-										},
+								"labels": map[string]interface{}{
+									meta.LabelHookChartName: "foochart",
+									meta.LabelHookType:      hook.TypePostApply,
+								},
+								"uid": "some-uid",
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"restartPolicy": "Never",
 									},
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
@@ -336,35 +328,33 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 				return dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme)
 			},
 			dryRun:   true,
-			hookType: hook.PreApply,
+			hookType: hook.TypePostApply,
 			hooks: hook.Map{
-				hook.PreApply: hook.List{
-					&hook.Hook{
-						Unstructured: &unstructured.Unstructured{
-							Object: map[string]interface{}{
-								"apiVersion": "batch/v1",
-								"kind":       "Job",
-								"metadata": map[string]interface{}{
-									"name":      "somehook",
-									"namespace": "bar",
-									"annotations": map[string]interface{}{
-										meta.AnnotationHookType: hook.PostApply,
-									},
-									"labels": map[string]interface{}{
-										meta.LabelHookChartName: "foochart",
-										meta.LabelHookType:      hook.PostApply,
-									},
+				hook.TypePostApply: hook.List{
+					hook.MustParse(&unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "batch/v1",
+							"kind":       "Job",
+							"metadata": map[string]interface{}{
+								"name":      "somehook",
+								"namespace": "bar",
+								"annotations": map[string]interface{}{
+									meta.AnnotationHookType: hook.TypePostApply,
 								},
-								"spec": map[string]interface{}{
-									"template": map[string]interface{}{
-										"spec": map[string]interface{}{
-											"restartPolicy": "Never",
-										},
+								"labels": map[string]interface{}{
+									meta.LabelHookChartName: "foochart",
+									meta.LabelHookType:      hook.TypePostApply,
+								},
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"restartPolicy": "Never",
 									},
 								},
 							},
 						},
-					},
+					}),
 				},
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
@@ -452,7 +442,7 @@ func TestHookExecutor_ExecHooks(t *testing.T) {
 func TestHookExecutor_ExecHooks_Nil(t *testing.T) {
 	var executor *HookExecutor
 
-	assert.NoError(t, executor.ExecHooks(&Chart{}, hook.PreApply))
+	assert.NoError(t, executor.ExecHooks(&Chart{}, hook.TypePreApply))
 }
 
 func newTestChart(hooks hook.Map) *Chart {

--- a/pkg/chart/processor_test.go
+++ b/pkg/chart/processor_test.go
@@ -101,42 +101,40 @@ func TestProcessor_Process(t *testing.T) {
 	}
 
 	expectedHooks := hook.Map{
-		hook.PostApply: hook.List{
-			&hook.Hook{
-				Unstructured: &unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"apiVersion": "batch/v1",
-						"kind":       "Job",
-						"metadata": map[string]interface{}{
-							"name":      "foobar-chart1",
-							"namespace": "bar",
-							"annotations": map[string]interface{}{
-								meta.AnnotationHookType: hook.PostApply,
-							},
-							"labels": map[string]interface{}{
-								"app.kubernetes.io/name":       "chart1",
-								"helm.sh/chart":                "chart1-0.1.0",
-								"app.kubernetes.io/instance":   "foobar",
-								"app.kubernetes.io/managed-by": "Tiller",
-								meta.LabelHookChartName:        "foobar",
-								meta.LabelHookType:             hook.PostApply,
-							},
+		hook.TypePostApply: hook.List{
+			hook.MustParse(&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"metadata": map[string]interface{}{
+						"name":      "foobar-chart1",
+						"namespace": "bar",
+						"annotations": map[string]interface{}{
+							meta.AnnotationHookType: hook.TypePostApply,
 						},
-						"spec": map[string]interface{}{
-							"template": map[string]interface{}{
-								"spec": map[string]interface{}{
-									"restartPolicy": "Never",
-									"containers": []interface{}{
-										map[string]interface{}{
-											"name":            "chart1",
-											"image":           "nginx:stable",
-											"imagePullPolicy": "IfNotPresent",
-											"ports": []interface{}{
-												map[string]interface{}{
-													"containerPort": int64(80),
-													"protocol":      "TCP",
-													"name":          "http",
-												},
+						"labels": map[string]interface{}{
+							"app.kubernetes.io/name":       "chart1",
+							"helm.sh/chart":                "chart1-0.1.0",
+							"app.kubernetes.io/instance":   "foobar",
+							"app.kubernetes.io/managed-by": "Tiller",
+							meta.LabelHookChartName:        "foobar",
+							meta.LabelHookType:             hook.TypePostApply,
+						},
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"restartPolicy": "Never",
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":            "chart1",
+										"image":           "nginx:stable",
+										"imagePullPolicy": "IfNotPresent",
+										"ports": []interface{}{
+											map[string]interface{}{
+												"containerPort": int64(80),
+												"protocol":      "TCP",
+												"name":          "http",
 											},
 										},
 									},
@@ -145,7 +143,7 @@ func TestProcessor_Process(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 		},
 	}
 
@@ -168,5 +166,5 @@ func TestProcessor_ProcessUnsupportedHook(t *testing.T) {
 	_, err := p.Process(config)
 
 	require.Error(t, err)
-	assert.Equal(t, `while parsing template "chart1/templates/hook.yaml": invalid hook "foobar-chart1": unsupported hook type "foo", allowed values are: [pre-apply post-apply pre-delete post-delete]`, err.Error())
+	assert.Equal(t, `while parsing template "chart1/templates/hook.yaml": invalid hook "foobar-chart1": unsupported hook type "foo", allowed values are: [post-apply post-delete pre-apply pre-delete]`, err.Error())
 }

--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -260,7 +260,7 @@ func (o *ApplyOptions) Run() error {
 
 		defer os.Remove(f.Name())
 
-		err = o.HookExecutor.ExecHooks(c, hook.PreApply)
+		err = o.HookExecutor.ExecHooks(c, hook.TypePreApply)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func (o *ApplyOptions) Run() error {
 			return err
 		}
 
-		return o.HookExecutor.ExecHooks(c, hook.PostApply)
+		return o.HookExecutor.ExecHooks(c, hook.TypePostApply)
 	})
 	if err != nil {
 		return err

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -204,7 +204,7 @@ func (o *DeleteOptions) DeleteChart(c *chart.Chart) error {
 
 	resources.SortInfosByKind(infos, resources.DeleteOrder)
 
-	err = o.HookExecutor.ExecHooks(c, hook.PreDelete)
+	err = o.HookExecutor.ExecHooks(c, hook.TypePreDelete)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func (o *DeleteOptions) DeleteChart(c *chart.Chart) error {
 		return err
 	}
 
-	err = o.HookExecutor.ExecHooks(c, hook.PostDelete)
+	err = o.HookExecutor.ExecHooks(c, hook.TypePostDelete)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/render.go
+++ b/pkg/cmd/render.go
@@ -68,7 +68,7 @@ func NewRenderOptions(streams genericclioptions.IOStreams) *RenderOptions {
 }
 
 func (o *RenderOptions) Validate() error {
-	if o.HookType != "" && o.HookType != "all" && !hook.IsSupportedType(o.HookType) {
+	if o.HookType != "" && o.HookType != "all" && !hook.SupportedTypes.Has(o.HookType) {
 		return hook.NewUnsupportedTypeError(o.HookType)
 	}
 

--- a/pkg/cmd/render_test.go
+++ b/pkg/cmd/render_test.go
@@ -100,9 +100,9 @@ spec:
 
 func TestRenderCmd_Validate(t *testing.T) {
 	tests := []struct {
-		name        string
-		hookType    string
-		expectedErr string
+		name      string
+		hookType  string
+		expectErr bool
 	}{
 		{
 			name: "empty hook type",
@@ -112,9 +112,9 @@ func TestRenderCmd_Validate(t *testing.T) {
 			hookType: "all",
 		},
 		{
-			name:        "invalid hook type",
-			hookType:    "invalid-hook-type",
-			expectedErr: `unsupported hook type "invalid-hook-type", allowed values are: [pre-apply post-apply pre-delete post-delete]`,
+			name:      "invalid hook type",
+			hookType:  "invalid-hook-type",
+			expectErr: true,
 		},
 	}
 
@@ -126,9 +126,8 @@ func TestRenderCmd_Validate(t *testing.T) {
 
 			err := o.Validate()
 
-			if test.expectedErr != "" {
+			if test.expectErr {
 				require.Error(t, err)
-				assert.Equal(t, test.expectedErr, err.Error())
 			} else {
 				require.NoError(t, err)
 			}
@@ -226,11 +225,11 @@ spec:
 		},
 		{
 			name:     "render pre-apply hooks",
-			hookType: hook.PreApply,
+			hookType: hook.TypePreApply,
 		},
 		{
 			name:     "render post-apply hooks",
-			hookType: hook.PostApply,
+			hookType: hook.TypePostApply,
 			expected: `---
 apiVersion: batch/v1
 kind: Job

--- a/pkg/hook/collections.go
+++ b/pkg/hook/collections.go
@@ -26,12 +26,10 @@ func (m Map) Add(hooks ...*Hook) Map {
 }
 
 func (m Map) add(h *Hook) Map {
-	hookType := h.Type()
-
-	if m[hookType] == nil {
-		m[hookType] = List{h}
+	if m[h.Type] == nil {
+		m[h.Type] = List{h}
 	} else {
-		m[hookType] = append(m[hookType], h)
+		m[h.Type] = append(m[h.Type], h)
 	}
 
 	return m

--- a/pkg/hook/collections_test.go
+++ b/pkg/hook/collections_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newTestHook(name, hookType string) *Hook {
-	return &Hook{newUnstructured(name, hookType)}
+	return MustParse(newUnstructured(name, hookType))
 }
 
 func newUnstructured(name, hookType string) *unstructured.Unstructured {
@@ -40,30 +40,30 @@ func newUnstructured(name, hookType string) *unstructured.Unstructured {
 func TestMap(t *testing.T) {
 	m := Map{}
 
-	m.Add(newTestHook("foo", PreApply))
-	m.Add(newTestHook("bar", PostApply))
-	m.Add(newTestHook("baz", PostApply))
+	m.Add(newTestHook("foo", TypePreApply))
+	m.Add(newTestHook("bar", TypePostApply))
+	m.Add(newTestHook("baz", TypePostApply))
 
 	assert.Len(t, m, 2)
-	assert.Len(t, m[PreDelete], 0)
-	assert.Len(t, m[PreApply], 1)
-	assert.Len(t, m[PostApply], 2)
+	assert.Len(t, m[TypePreDelete], 0)
+	assert.Len(t, m[TypePreApply], 1)
+	assert.Len(t, m[TypePostApply], 2)
 
 	assert.Equal(
 		t,
 		List{
-			newTestHook("bar", PostApply),
-			newTestHook("baz", PostApply),
+			newTestHook("bar", TypePostApply),
+			newTestHook("baz", TypePostApply),
 		},
-		m[PostApply],
+		m[TypePostApply],
 	)
 
 	assert.ElementsMatch(
 		t,
 		[]runtime.Object{
-			newUnstructured("foo", PreApply),
-			newUnstructured("bar", PostApply),
-			newUnstructured("baz", PostApply),
+			newUnstructured("foo", TypePreApply),
+			newUnstructured("bar", TypePostApply),
+			newUnstructured("baz", TypePostApply),
 		},
 		m.All().ToObjectList(),
 	)
@@ -71,8 +71,8 @@ func TestMap(t *testing.T) {
 
 func TestList_EachItem(t *testing.T) {
 	l := List{
-		newTestHook("bar", PostApply),
-		newTestHook("baz", PostApply),
+		newTestHook("bar", TypePostApply),
+		newTestHook("baz", TypePostApply),
 	}
 
 	names := []string{}

--- a/pkg/hook/errors.go
+++ b/pkg/hook/errors.go
@@ -23,7 +23,7 @@ func (e UnsupportedTypeError) Error() string {
 	return fmt.Sprintf(
 		"unsupported hook type %q, allowed values are: %v",
 		e.Type,
-		SupportedTypes,
+		SupportedTypes.List(),
 	)
 }
 

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -1,157 +1,41 @@
 package hook
 
 import (
-	"fmt"
-	"strconv"
 	"time"
 
-	"github.com/martinohmann/kubectl-chart/pkg/meta"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Supported types of hooks.
 const (
-	PreApply   = "pre-apply"
-	PostApply  = "post-apply"
-	PreDelete  = "pre-delete"
-	PostDelete = "post-delete"
+	TypePostApply  = "post-apply"
+	TypePostDelete = "post-delete"
+	TypePreApply   = "pre-apply"
+	TypePreDelete  = "pre-delete"
 )
 
-// SupportedTypes contains a list of supported hook types.
-var SupportedTypes = []string{PreApply, PostApply, PreDelete, PostDelete}
+// SupportedTypes contains all supported hook types.
+var SupportedTypes = sets.NewString(TypePostApply, TypePostDelete, TypePreApply, TypePreDelete)
 
-// jobGK is the GroupKind that a hook resource must have.
-var jobGK = schema.GroupKind{Group: "batch", Kind: "Job"}
-
-// LabelSelector returns a selector which can be used to find hooks of given
-// type for given chart in a cluster.
-func LabelSelector(chartName, hookType string) string {
-	return fmt.Sprintf("%s=%s,%s=%s", meta.LabelHookChartName, chartName, meta.LabelHookType, hookType)
-}
-
-// Hook gets executed before or after apply/delete depending on its type. It
-// wraps an unstructured object to enhance it with some extra logic for
-// validation and working with hook options.
+// Hook gets executed before or after apply/delete depending on its type..
 type Hook struct {
 	*unstructured.Unstructured
-}
 
-// New creates a new hook from a runtime object.
-func New(obj runtime.Object) (*Hook, error) {
-	u, ok := obj.(*unstructured.Unstructured)
-	if !ok {
-		return nil, errors.Errorf("obj is of type %T, expected *unstructured.Unstructured", obj)
-	}
+	// Type contains the hook type, e.g. post-apply.
+	Type string
 
-	h := &Hook{u}
+	// AllowFailure indicates whether the hook is allowed to fail or not. If true,
+	// hook errors are only printed and execution continues. If this is true,
+	// NoWait must not be true as well.
+	AllowFailure bool
 
-	err := Validate(h)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid hook %q", h.GetName())
-	}
+	// NoWait indicates whether it should be waited for the hook to complete or
+	// not. If true, AllowFailure must not be true and it is also not possible
+	// to detect possible hook failures.
+	NoWait bool
 
-	return h, nil
-}
-
-func (h *Hook) nestedString(fields ...string) string {
-	value, _, _ := unstructured.NestedString(h.Object, fields...)
-	return value
-}
-
-// restartPolicy gets the restartPolicy from the hook jobs pod spec.
-func (h *Hook) restartPolicy() corev1.RestartPolicy {
-	return corev1.RestartPolicy(h.nestedString("spec", "template", "spec", "restartPolicy"))
-}
-
-// Type returns the hook type, e.g. post-apply.
-func (h *Hook) Type() string {
-	return h.nestedString("metadata", "annotations", meta.AnnotationHookType)
-}
-
-// AllowFailure indicates whether the hook is allowed to fail or not. If true,
-// hook errors are only printed and execution continues. If this is true,
-// NoWait() must not return true as well.
-func (h *Hook) AllowFailure() bool {
-	value := h.nestedString("metadata", "annotations", meta.AnnotationHookAllowFailure)
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-
-	return b
-}
-
-// NoWait indicates whether it should be waited for the hook to complete or
-// not. If true, AllowFailure() must not return true and it is also not
-// possible to detect possible hook failures.
-func (h *Hook) NoWait() bool {
-	value := h.nestedString("metadata", "annotations", meta.AnnotationHookNoWait)
-	b, err := strconv.ParseBool(value)
-	if err != nil {
-		return false
-	}
-
-	return b
-}
-
-// WaitTimeout returns the timeout for waiting for hook completion and an error
-// if the annotation cannot be parsed.
-func (h *Hook) WaitTimeout() (time.Duration, error) {
-	value, found, _ := unstructured.NestedString(h.Object, "metadata", "annotations", meta.AnnotationHookWaitTimeout)
-	if !found {
-		return 0, nil
-	}
-
-	timeout, err := time.ParseDuration(value)
-	if err != nil {
-		return 0, err
-	}
-
-	return timeout, nil
-}
-
-// IsSupportedType returns true if typ is a supported hook type.
-func IsSupportedType(typ string) bool {
-	for _, t := range SupportedTypes {
-		if t == typ {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Validate returns an error if a hook has an unsupported type or resource kind
-// or if other resource fields have unsupported values.
-func Validate(h *Hook) error {
-	if h.GetKind() != jobGK.Kind {
-		return NewUnsupportedKindError(h.GetKind())
-	}
-
-	if !IsSupportedType(h.Type()) {
-		return NewUnsupportedTypeError(h.Type())
-	}
-
-	if h.restartPolicy() != corev1.RestartPolicyNever {
-		return NewUnsupportedRestartPolicyError(h.restartPolicy())
-	}
-
-	if h.NoWait() && h.AllowFailure() {
-		return NewIllegalAnnotationCombinationError(meta.AnnotationHookNoWait, meta.AnnotationHookAllowFailure)
-	}
-
-	timeout, err := h.WaitTimeout()
-	if err != nil {
-		return errors.Wrapf(err, "malformed annotation %q", meta.AnnotationHookWaitTimeout)
-	}
-
-	if h.NoWait() && timeout > 0 {
-		return NewIllegalAnnotationCombinationError(meta.AnnotationHookNoWait, meta.AnnotationHookWaitTimeout)
-	}
-
-	return err
+	// WaitTimeout sets a custom hook wait timeout. If zero, a default wait
+	// timeout will be used. Must be zero if NoWait is set to true.
+	WaitTimeout time.Duration
 }

--- a/pkg/hook/parse.go
+++ b/pkg/hook/parse.go
@@ -1,0 +1,99 @@
+package hook
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/martinohmann/kubectl-chart/pkg/meta"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// jobGK is the GroupKind that a hook resource must have.
+var jobGK = schema.GroupKind{Group: "batch", Kind: "Job"}
+
+// MustParse wraps Parse() and panics if parsing fails.
+func MustParse(obj runtime.Object) *Hook {
+	h, err := Parse(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return h
+}
+
+// Parse parses a runtime.Object into a *Hook. Returns errors if parsing fails.
+func Parse(obj runtime.Object) (*Hook, error) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, errors.Errorf("obj is of type %T, expected *unstructured.Unstructured", obj)
+	}
+
+	if u.GetKind() != jobGK.Kind {
+		return nil, NewUnsupportedKindError(u.GetKind())
+	}
+
+	annotations := u.GetAnnotations()
+
+	hookType := annotations[meta.AnnotationHookType]
+	if !SupportedTypes.Has(hookType) {
+		return nil, NewUnsupportedTypeError(hookType)
+	}
+
+	allowFailure := parseBool(annotations[meta.AnnotationHookAllowFailure])
+	noWait := parseBool(annotations[meta.AnnotationHookNoWait])
+
+	if noWait && allowFailure {
+		return nil, NewIllegalAnnotationCombinationError(meta.AnnotationHookNoWait, meta.AnnotationHookAllowFailure)
+	}
+
+	waitTimeout, err := parseDuration(annotations[meta.AnnotationHookWaitTimeout])
+	if err != nil {
+		return nil, errors.Wrapf(err, "malformed annotation %q", meta.AnnotationHookWaitTimeout)
+	}
+
+	if noWait && waitTimeout > 0 {
+		return nil, NewIllegalAnnotationCombinationError(meta.AnnotationHookNoWait, meta.AnnotationHookWaitTimeout)
+	}
+
+	restartPolicy := parseRestartPolicy(u)
+	if restartPolicy != corev1.RestartPolicyNever {
+		return nil, NewUnsupportedRestartPolicyError(restartPolicy)
+	}
+
+	h := &Hook{
+		Unstructured: u,
+		Type:         hookType,
+		AllowFailure: allowFailure,
+		NoWait:       noWait,
+		WaitTimeout:  waitTimeout,
+	}
+
+	return h, nil
+}
+
+func parseRestartPolicy(obj *unstructured.Unstructured) corev1.RestartPolicy {
+	value, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "restartPolicy")
+
+	return corev1.RestartPolicy(value)
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	return time.ParseDuration(s)
+}
+
+func parseBool(s string) bool {
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false
+	}
+
+	return b
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -32,3 +32,10 @@ func DefaultNamespace(obj runtime.Object, namespace string) error {
 
 	return nil
 }
+
+// GetObjectName returns the name from obj's metadata.
+func GetObjectName(obj runtime.Object) string {
+	accessor, _ := meta.Accessor(obj)
+
+	return accessor.GetName()
+}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -73,3 +73,9 @@ func TestDefaultNamespace(t *testing.T) {
 
 	assert.Equal(t, "foo", obj.GetNamespace())
 }
+
+func TestGetObjectHame(t *testing.T) {
+	obj := newUnstructured(schema.GroupVersionKind{}, nil)
+
+	assert.Equal(t, "foo", GetObjectName(obj))
+}


### PR DESCRIPTION
Instead of defining methods for retrieving hook attribute, we parse
hooks once and store the parsed attributes.

This PR also moves some code around and renames hook type constants (eg. `hook.PreApply` to `hook.TypePreApply`)